### PR TITLE
Updated upload-artifact action from v3 -> v4

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -87,7 +87,7 @@ jobs:
           # 12. Upload Test Reports (Optional)
       - name: Upload Test Report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: junit-test-report
           path: reports/junit.xml

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -89,5 +89,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: junit-test-report
+          name: dist-${{ matrix.python-version }}-junit-test-report
           path: reports/junit.xml


### PR DESCRIPTION
Got deprecation warning:

>The following artifacts were uploaded using a version of actions/upload-artifact that is scheduled for deprecation: "junit-test-report". Please update your workflow to use v4 of the artifact actions. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/